### PR TITLE
augment headers without links only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
-## 1.0.0-FINAL (2018-10-05)
+## 1.0.3-FINAL (2021-11-12)
+
+  - fix #6: augment headers without links only
+  - fix #7: upgrade to confluence 7.13.0
+  - fix #3: remove extraneous package export
+
+## 1.0.2-FINAL (2018-10-05)
 
   - initial version

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.coldrye.confluence.plugins</groupId>
     <artifactId>clickable-anchors-plugin</artifactId>
-    <version>1.0.2-FINAL</version>
+    <version>1.0.3-FINAL</version>
 
     <organization>
         <name>coldrye</name>

--- a/src/main/resources/js/clickable-anchors-plugin-page.js
+++ b/src/main/resources/js/clickable-anchors-plugin-page.js
@@ -8,17 +8,12 @@ AJS.$(document).ready(function () {
       .addClass("clickable-anchors-plugin-link");
   };
 
-  AJS.$("#content span.confluence-anchor-link").each(function (_, elt) {
-
-    createAnchor(elt.id)
-      .text("#")
-      .appendTo(elt);
-  });
-
   AJS.$("#content :header[id]").each(function (_, elt) {
 
-    createAnchor(elt.id)
-      .append($(elt).contents())
-      .appendTo(elt);
+    var header = $(elt);
+    var anchor = createAnchor(elt.id);
+    if (header.find('a').length == 0) {
+      header.contents().wrap(anchor);
+    }
   });
 });


### PR DESCRIPTION
fix #6:

- bump version to 1.0.3-FINAL
- augment headers without links only